### PR TITLE
Use PHP DNS Direct Query Module instead of php dns_get_record() to specify the nameserver to use for the query.

### DIFF
--- a/.idea/spfcheck.iml
+++ b/.idea/spfcheck.iml
@@ -4,15 +4,5 @@
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library name="PHP Runtime" type="php">
-        <CLASSES>
-          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
-        </CLASSES>
-        <SOURCES>
-          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
-        </SOURCES>
-      </library>
-    </orderEntry>
   </component>
 </module>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
+sudo: required
+
 language: php
+
+services:
+  - docker
 
 php:
   - 5.4
@@ -16,6 +21,7 @@ matrix:
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
+  - docker run -d --rm --name pdns -p 53:53/udp -p 53:53/tcp -p 80:80 -e "WEBPASSWD=password" raspberrypython/powerdns-sqlite3:latest
 
 script:
   - mkdir -p build/logs

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ Run `composer require mika56/spfcheck` or add this to your composer.json:
 ```json
 {
   "require": {
-    "mika56/spfcheck": "1.0.0"
+    "mika56/spfcheck": "^1"
   }
 }
 ```
 
 ## Usage
-Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, you have two options: DNSRecordGetter which uses PHP's DNS functions to get data or DNSRecordGetterDirect which uses the [PHP DNS Direct Query Module](https://github.com/purplepixie/phpdns) to get data.
+Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, you have two options:
+- `DNSRecordGetter` which uses PHP's DNS functions to get data
+- `DNSRecordGetterDirect` which uses the [PHP DNS Direct Query Module](https://github.com/purplepixie/phpdns) to get data.
 ```php
 <?php
 use Mika56\SPFCheck\SPFCheck;
@@ -30,7 +32,7 @@ require('vendor/autoload.php');
 $checker = new SPFCheck(new DNSRecordGetter()); // Uses php's dns_get_record method for lookup.
 var_dump($checker->isIPAllowed('127.0.0.1', 'test.com'));
 
-or
+// or
 
 $checker = new SPFCheck(new DNSRecordGetterDirect("8.8.8.8")); // Uses phpdns, allowing you to set the nameserver you wish to use for the dns queries.
 var_dump($checker->isIPAllowed('127.0.0.1', 'test.com'));

--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ Run `composer require mika56/spfcheck` or add this to your composer.json:
 ```
 
 ## Usage
-Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, only DNSRecordGetter exists, which uses the [PHP DNS Direct Query Module](https://github.com/purplepixie/phpdns) to get data.
+Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, you have two options: DNSRecordGetter which uses PHP's DNS functions to get data or DNSRecordGetterDirect which uses the [PHP DNS Direct Query Module](https://github.com/purplepixie/phpdns) to get data.
 ```php
 <?php
 use Mika56\SPFCheck\SPFCheck;
 use Mika56\SPFCheck\DNSRecordGetter;
 
 require('vendor/autoload.php');
-$checker = new SPFCheck(new DNSRecordGetter("8.8.8.8")); // 8.8.8.8 is the nameserver you wish to use for the dns queries.
+
+$checker = new SPFCheck(new DNSRecordGetter()); // Uses php's dns_get_record method for lookup.
+var_dump($checker->isIPAllowed('127.0.0.1', 'test.com'));
+
+or
+
+$checker = new SPFCheck(new DNSRecordGetterDirect("8.8.8.8")); // Uses phpdns, allowing you to set the nameserver you wish to use for the dns queries.
 var_dump($checker->isIPAllowed('127.0.0.1', 'test.com'));
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ Run `composer require mika56/spfcheck` or add this to your composer.json:
 ```json
 {
   "require": {
-    "mika56/spfcheck": "dev-master"
+    "mika56/spfcheck": "1.0.0"
   }
 }
 ```
 
 ## Usage
-Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, only DNSRecordGetter exists, which uses PHP's DNS functions to get data.
+Create a new instance of SPFCheck. The constructor requires a DNSRecordGetterInterface to be passed. Currently, only DNSRecordGetter exists, which uses the [PHP DNS Direct Query Module](https://github.com/purplepixie/phpdns) to get data.
 ```php
 <?php
 use Mika56\SPFCheck\SPFCheck;
 use Mika56\SPFCheck\DNSRecordGetter;
 
 require('vendor/autoload.php');
-$checker = new SPFCheck(new DNSRecordGetter());
+$checker = new SPFCheck(new DNSRecordGetter("8.8.8.8")); // 8.8.8.8 is the nameserver you wish to use for the dns queries.
 var_dump($checker->isIPAllowed('127.0.0.1', 'test.com'));
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,16 @@
         {
             "name": "Mikael Peigney",
             "email": "mikael.peigney@supinfo.com"
+        },
+        {
+            "name": "Brian Tafoya",
+            "email": "btafoya@briantafoya.com"
         }
     ],
     "require": {
         "symfony/http-foundation": "2.8.* || ^3.0",
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "purplepixie/phpdns": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "483a53227233a1f66cf4b8e5bc8be668",
-    "content-hash": "e4350dc22c1ec012a646dd83da675152",
+    "content-hash": "707f73f9e20f0f8c6972a4da57daf2e8",
     "packages": [
         {
             "name": "ircmaxell/password-compat",
@@ -47,20 +46,61 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
-            "name": "symfony/http-foundation",
-            "version": "v2.8.15",
+            "name": "purplepixie/phpdns",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "216c111ac427f5f773c6a8bfc0c15f0a7dd74876"
+                "url": "https://github.com/purplepixie/phpdns.git",
+                "reference": "2eef80a6d9bbe75a600aea4ec90540e0d7adb095"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/216c111ac427f5f773c6a8bfc0c15f0a7dd74876",
-                "reference": "216c111ac427f5f773c6a8bfc0c15f0a7dd74876",
+                "url": "https://api.github.com/repos/purplepixie/phpdns/zipball/2eef80a6d9bbe75a600aea4ec90540e0d7adb095",
+                "reference": "2eef80a6d9bbe75a600aea4ec90540e0d7adb095",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PurplePixie": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPLv3"
+            ],
+            "authors": [
+                {
+                    "name": "David Cutting",
+                    "email": "dcutting@purplepixie.org"
+                }
+            ],
+            "description": "PHP DNS Direct Query Module",
+            "time": "2016-08-29T18:18:49+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.8.26",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "9ff3a0b3756ace2e3da7dded37e920ee776faa4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9ff3a0b3756ace2e3da7dded37e920ee776faa4e",
+                "reference": "9ff3a0b3756ace2e3da7dded37e920ee776faa4e",
                 "shasum": ""
             },
             "require": {
@@ -102,20 +142,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-27 04:20:28"
+            "time": "2017-07-17T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
+                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
                 "shasum": ""
             },
             "require": {
@@ -127,7 +167,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -161,20 +201,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-06-09T14:24:12+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php54.git",
-                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0"
+                "reference": "7dd1a8b9f0442273fdfeb1c4f5eaff6890a82789"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
-                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/7dd1a8b9f0442273fdfeb1c4f5eaff6890a82789",
+                "reference": "7dd1a8b9f0442273fdfeb1c4f5eaff6890a82789",
                 "shasum": ""
             },
             "require": {
@@ -183,7 +223,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -219,20 +259,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-06-09T08:25:21+00:00"
         },
         {
             "name": "symfony/polyfill-php55",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php55.git",
-                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67"
+                "reference": "94566239a7720cde0820f15f0cc348ddb51ba51d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/03e3f0350bca2220e3623a0e340eef194405fc67",
-                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67",
+                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/94566239a7720cde0820f15f0cc348ddb51ba51d",
+                "reference": "94566239a7720cde0820f15f0cc348ddb51ba51d",
                 "shasum": ""
             },
             "require": {
@@ -242,7 +282,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -275,7 +315,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-06-09T08:25:21+00:00"
         }
     ],
     "packages-dev": [
@@ -331,7 +371,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -427,20 +467,20 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
@@ -476,31 +516,31 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
+                "phpspec/phpspec": "^2.5|^3.2",
                 "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
@@ -539,7 +579,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -601,7 +641,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -648,7 +688,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -689,29 +729,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -733,20 +778,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -782,20 +827,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.31",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -854,7 +899,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-09 02:45:31"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -910,7 +955,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -957,7 +1002,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1015,20 +1060,20 @@
                 "github",
                 "test"
             ],
-            "time": "2016-01-20 17:35:46"
+            "time": "2016-01-20T17:35:46+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
@@ -1079,27 +1124,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -1131,7 +1176,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1181,7 +1226,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1248,7 +1293,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1299,20 +1344,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1352,7 +1397,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1387,20 +1432,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b522856007b258f46d5ee35d3b7b235c11e76e86"
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b522856007b258f46d5ee35d3b7b235c11e76e86",
-                "reference": "b522856007b258f46d5ee35d3b7b235c11e76e86",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0b8541d18507d10204a08384640ff6df3c739ebe",
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe",
                 "shasum": ""
             },
             "require": {
@@ -1443,25 +1488,25 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-10 08:21:45"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f"
+                "reference": "32a3c6b3398de5db8ed381f4ef92970c59c2fcdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d5643cd095e5e37d31e004bb2606b5dd7e96602f",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/32a3c6b3398de5db8ed381f4ef92970c59c2fcdd",
+                "reference": "32a3c6b3398de5db8ed381f4ef92970c59c2fcdd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/debug": "~2.7,>=2.7.2|~3.0.0",
+                "symfony/debug": "^2.7.2|~3.0.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
@@ -1504,20 +1549,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-06 11:59:35"
+            "time": "2017-07-29T21:26:04+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1"
+                "reference": "236ca98a425758cc8c2ff2db423bfe4d1a736b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/62a68f640456f6761d752c62d81631428ef0d8a1",
-                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/236ca98a425758cc8c2ff2db423bfe4d1a736b8c",
+                "reference": "236ca98a425758cc8c2ff2db423bfe4d1a736b8c",
                 "shasum": ""
             },
             "require": {
@@ -1529,7 +1574,7 @@
             },
             "require-dev": {
                 "symfony/class-loader": "~2.2|~3.0.0",
-                "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2|~3.0.0"
+                "symfony/http-kernel": "~2.3.24|~2.5.9|^2.6.2|~3.0.0"
             },
             "type": "library",
             "extra": {
@@ -1561,20 +1606,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15 12:53:17"
+            "time": "2017-07-28T15:21:22+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
+                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
-                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1377400fd641d7d1935981546aaef780ecd5bf6d",
+                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d",
                 "shasum": ""
             },
             "require": {
@@ -1582,7 +1627,7 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/config": "^2.0.5|~3.0.0",
                 "symfony/dependency-injection": "~2.6|~3.0.0",
                 "symfony/expression-language": "~2.6|~3.0.0",
                 "symfony/stopwatch": "~2.3|~3.0.0"
@@ -1621,20 +1666,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 01:43:15"
+            "time": "2017-06-02T07:47:27+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "a3784111af9f95f102b6411548376e1ae7c93898"
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a3784111af9f95f102b6411548376e1ae7c93898",
-                "reference": "a3784111af9f95f102b6411548376e1ae7c93898",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/714b1036010c354ae2b25d7f9ca27e14e265e9f2",
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2",
                 "shasum": ""
             },
             "require": {
@@ -1670,26 +1715,30 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 04:28:30"
+            "time": "2017-07-11T07:12:11+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.1",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "65e64a4f99cbaeae718573c3347fbe800f3f6661"
+                "reference": "c2c124b7f9de79f4a64dc011f041a3a2c768b913"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/65e64a4f99cbaeae718573c3347fbe800f3f6661",
-                "reference": "65e64a4f99cbaeae718573c3347fbe800f3f6661",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/c2c124b7f9de79f4a64dc011f041a3a2c768b913",
+                "reference": "c2c124b7f9de79f4a64dc011f041a3a2c768b913",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
             "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
                 "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
@@ -1698,7 +1747,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1728,20 +1777,20 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-12-12 13:31:08"
+            "time": "2017-06-12T13:35:45+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "35bae476693150728b0eb51647faac82faf9aaca"
+                "reference": "e02577b841394a78306d7b547701bb7bb705bad5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/35bae476693150728b0eb51647faac82faf9aaca",
-                "reference": "35bae476693150728b0eb51647faac82faf9aaca",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e02577b841394a78306d7b547701bb7bb705bad5",
+                "reference": "e02577b841394a78306d7b547701bb7bb705bad5",
                 "shasum": ""
             },
             "require": {
@@ -1777,20 +1826,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.15",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
                 "shasum": ""
             },
             "require": {
@@ -1826,7 +1875,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-14 16:15:57"
+            "time": "2017-06-01T20:52:29+00:00"
         }
     ],
     "aliases": [],

--- a/src/DNSRecordGetter.php
+++ b/src/DNSRecordGetter.php
@@ -12,109 +12,109 @@ use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
 
 class DNSRecordGetter implements DNSRecordGetterInterface
 {
-	protected $requestCount = 0;
+    protected $requestCount = 0;
 
-	/**
-	 * @param $domain string The domain to get SPF record
-	 * @return string[] The SPF record(s)
-	 * @throws DNSLookupException
-	 */
-	public function getSPFRecordForDomain($domain)
-	{
-		$records = dns_get_record($domain, DNS_TXT | DNS_SOA);
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+    /**
+     * @param $domain string The domain to get SPF record
+     * @return string[] The SPF record(s)
+     * @throws DNSLookupException
+     */
+    public function getSPFRecordForDomain($domain)
+    {
+        $records = dns_get_record($domain, DNS_TXT | DNS_SOA);
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-		$spfRecords = array();
-		foreach ($records as $record) {
-			if ($record['type'] == 'TXT') {
-				$txt = strtolower($record['txt']);
-				// An SPF record can be empty (no mechanism)
-				if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
-					$spfRecords[] = $txt;
-				}
-			}
-		}
+        $spfRecords = array();
+        foreach ($records as $record) {
+            if ($record['type'] == 'TXT') {
+                $txt = strtolower($record['txt']);
+                // An SPF record can be empty (no mechanism)
+                if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
+                    $spfRecords[] = $txt;
+                }
+            }
+        }
 
-		return $spfRecords;
-	}
+        return $spfRecords;
+    }
 
-	public function resolveA($domain, $ip4only = false)
-	{
-		$records = dns_get_record($domain, $ip4only ? DNS_A : (DNS_A | DNS_AAAA));
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+    public function resolveA($domain, $ip4only = false)
+    {
+        $records = dns_get_record($domain, $ip4only ? DNS_A : (DNS_A | DNS_AAAA));
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-		$addresses = [];
+        $addresses = [];
 
-		foreach ($records as $record) {
-			if ($record['type'] === "A") {
-				$addresses[] = $record['ip'];
-			} elseif ($record['type'] === 'AAAA') {
-				$addresses[] = $record['ipv6'];
-			}
-		}
+        foreach ($records as $record) {
+            if ($record['type'] === "A") {
+                $addresses[] = $record['ip'];
+            } elseif ($record['type'] === 'AAAA') {
+                $addresses[] = $record['ipv6'];
+            }
+        }
 
-		return $addresses;
-	}
+        return $addresses;
+    }
 
-	public function resolveMx($domain)
-	{
-		$records = dns_get_record($domain, DNS_MX);
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+    public function resolveMx($domain)
+    {
+        $records = dns_get_record($domain, DNS_MX);
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-		$addresses = [];
+        $addresses = [];
 
-		foreach ($records as $record) {
-			if ($record['type'] === "MX") {
-				$addresses[] = $record['target'];
-			}
-		}
+        foreach ($records as $record) {
+            if ($record['type'] === "MX") {
+                $addresses[] = $record['target'];
+            }
+        }
 
-		return $addresses;
-	}
+        return $addresses;
+    }
 
-	public function resolvePtr($ipAddress)
-	{
-		if (stripos($ipAddress, '.') !== false) {
-			// IPv4
-			$revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
-		} else {
-			$literal = implode(':', array_map(function ($b) {
-				return sprintf('%04x', $b);
-			}, unpack('n*', inet_pton($ipAddress))));
-			$revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
-		}
+    public function resolvePtr($ipAddress)
+    {
+        if (stripos($ipAddress, '.') !== false) {
+            // IPv4
+            $revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
+        } else {
+            $literal = implode(':', array_map(function ($b) {
+                return sprintf('%04x', $b);
+            }, unpack('n*', inet_pton($ipAddress))));
+            $revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
+        }
 
-		$revs = array_map(function ($e) {
-			return $e['target'];
-		}, dns_get_record($revIp, DNS_PTR));
+        $revs = array_map(function ($e) {
+            return $e['target'];
+        }, dns_get_record($revIp, DNS_PTR));
 
-		return array_slice($revs, 0, 10);
-	}
+        return array_slice($revs, 0, 10);
+    }
 
-	public function exists($domain)
-	{
-		try {
-			return count($this->resolveA($domain, true)) > 0;
-		} catch (DNSLookupException $e) {
-			return false;
-		}
-	}
+    public function exists($domain)
+    {
+        try {
+            return count($this->resolveA($domain, true)) > 0;
+        } catch (DNSLookupException $e) {
+            return false;
+        }
+    }
 
-	public function resetRequestCount()
-	{
-		$this->requestCount = 0;
-	}
+    public function resetRequestCount()
+    {
+        $this->requestCount = 0;
+    }
 
-	public function countRequest()
-	{
-		if (++$this->requestCount > 10) {
-			throw new DNSLookupLimitReachedException();
-		}
-	}
+    public function countRequest()
+    {
+        if (++$this->requestCount > 10) {
+            throw new DNSLookupLimitReachedException();
+        }
+    }
 }

--- a/src/DNSRecordGetter.php
+++ b/src/DNSRecordGetter.php
@@ -6,9 +6,6 @@
 
 namespace Mika56\SPFCheck;
 
-
-use function array_merge;
-use Exception;
 use Mika56\SPFCheck\Exception\DNSLookupException;
 use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
 use PurplePixie\PhpDns\DNSQuery;
@@ -192,7 +189,7 @@ class DNSRecordGetter implements DNSRecordGetterInterface
 
 		    switch($type) {
 			    default:
-			    	throw new Exception("Unsupported type " . $type . ".");
+			    	throw new \Exception("Unsupported type " . $type . ".");
 			    	break;
 			    case "A":
 				    $response[] = array(

--- a/src/DNSRecordGetter.php
+++ b/src/DNSRecordGetter.php
@@ -6,242 +6,115 @@
 
 namespace Mika56\SPFCheck;
 
+
 use Mika56\SPFCheck\Exception\DNSLookupException;
 use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
-use PurplePixie\PhpDns\DNSQuery;
 
 class DNSRecordGetter implements DNSRecordGetterInterface
 {
-    protected $requestCount = 0;
-	protected $nameserver = "8.8.8.8";
-	protected $port = 53;
-	protected $timeout = 30;
-	protected $udp = true;
-
-	const DNS_A = 'A';
-	const DNS_CNAME = "CNAME";
-	const DNS_HINFO = "HINFO";
-	const DNS_CAA = "CAA";
-	const DNS_MX = "MX";
-	const DNS_NS = "NS";
-	const DNS_PTR = "PTR";
-	const DNS_SOA = "SOA";
-	const DNS_TXT = "TXT";
-	const DNS_AAAA = "AAAA";
-	const DNS_SRV = "SRV";
-	const DNS_NAPTR = "NAPTR";
-	const DNS_A6 = "A6";
-	const DNS_ALL = "ALL";
-	const DNS_ANY = "ANY";
+	protected $requestCount = 0;
 
 	/**
-	 * DNSRecordGetter constructor.
-	 *
-	 * @param string $nameserver
-	 * @param string $port
-	 * @param string $timeout
+	 * @param $domain string The domain to get SPF record
+	 * @return string[] The SPF record(s)
+	 * @throws DNSLookupException
 	 */
-	public function __construct($nameserver = "8.8.8.8", $port = "53", $timeout = "30", $udp = true) {
-		$this->nameserver = $nameserver;
-		$this->port = $port;
-		$this->timeout = $timeout;
-		$this->udp = $udp;
+	public function getSPFRecordForDomain($domain)
+	{
+		$records = dns_get_record($domain, DNS_TXT | DNS_SOA);
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
+
+		$spfRecords = array();
+		foreach ($records as $record) {
+			if ($record['type'] == 'TXT') {
+				$txt = strtolower($record['txt']);
+				// An SPF record can be empty (no mechanism)
+				if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
+					$spfRecords[] = $txt;
+				}
+			}
+		}
+
+		return $spfRecords;
 	}
 
-	/**
-     * @param $domain string The domain to get SPF record
-     * @return string[] The SPF record(s)
-     * @throws DNSLookupException
-     */
-    public function getSPFRecordForDomain($domain)
-    {
-        $records = $this->dns_get_record($domain, "TXT");
-        if (false === $records) {
-            throw new DNSLookupException;
-        }
+	public function resolveA($domain, $ip4only = false)
+	{
+		$records = dns_get_record($domain, $ip4only ? DNS_A : (DNS_A | DNS_AAAA));
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
 
-        $spfRecords = array();
-        foreach ($records as $record) {
-            if ($record['type'] == 'TXT') {
-                $txt = strtolower($record['txt']);
-                // An SPF record can be empty (no mechanism)
-                if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
-                    $spfRecords[] = $txt;
-                }
-            }
-        }
+		$addresses = [];
 
-        return $spfRecords;
-    }
+		foreach ($records as $record) {
+			if ($record['type'] === "A") {
+				$addresses[] = $record['ip'];
+			} elseif ($record['type'] === 'AAAA') {
+				$addresses[] = $record['ipv6'];
+			}
+		}
 
-    public function resolveA($domain, $ip4only = false)
-    {
+		return $addresses;
+	}
 
-        $records = $this->dns_get_record($domain, "A");
+	public function resolveMx($domain)
+	{
+		$records = dns_get_record($domain, DNS_MX);
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
 
-        if(!$ip4only) {
-        	$ip6 = $this->dns_get_record($domain, "AAAA");
-        	if($ip6) {
-		        $records = array_merge($records,$ip6);
-	        }
-        }
+		$addresses = [];
 
-        if (false === $records) {
-            throw new DNSLookupException;
-        }
+		foreach ($records as $record) {
+			if ($record['type'] === "MX") {
+				$addresses[] = $record['target'];
+			}
+		}
 
-        $addresses = [];
+		return $addresses;
+	}
 
-        foreach ($records as $record) {
-            if ($record['type'] === "A") {
-                $addresses[] = $record['ip'];
-            } elseif ($record['type'] === 'AAAA') {
-                $addresses[] = $record['ipv6'];
-            }
-        }
+	public function resolvePtr($ipAddress)
+	{
+		if (stripos($ipAddress, '.') !== false) {
+			// IPv4
+			$revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
+		} else {
+			$literal = implode(':', array_map(function ($b) {
+				return sprintf('%04x', $b);
+			}, unpack('n*', inet_pton($ipAddress))));
+			$revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
+		}
 
-        return $addresses;
-    }
+		$revs = array_map(function ($e) {
+			return $e['target'];
+		}, dns_get_record($revIp, DNS_PTR));
 
-    public function resolveMx($domain)
-    {
-        $records = $this->dns_get_record($domain, "MX");
-        if (false === $records) {
-            throw new DNSLookupException;
-        }
+		return array_slice($revs, 0, 10);
+	}
 
-        $addresses = [];
+	public function exists($domain)
+	{
+		try {
+			return count($this->resolveA($domain, true)) > 0;
+		} catch (DNSLookupException $e) {
+			return false;
+		}
+	}
 
-        foreach ($records as $record) {
-            if ($record['type'] === "MX") {
-                $addresses[] = $record['target'];
-            }
-        }
+	public function resetRequestCount()
+	{
+		$this->requestCount = 0;
+	}
 
-        return $addresses;
-    }
-
-    public function resolvePtr($ipAddress)
-    {
-        if (stripos($ipAddress, '.') !== false) {
-            // IPv4
-            $revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
-        } else {
-            $literal = implode(':', array_map(function ($b) {
-                return sprintf('%04x', $b);
-            }, unpack('n*', inet_pton($ipAddress))));
-            $revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
-        }
-
-        $revs = array_map(function ($e) {
-            return $e['target'];
-        }, dns_get_record($revIp, "PTR"));
-
-        return array_slice($revs, 0, 10);
-    }
-
-    public function exists($domain)
-    {
-        try {
-            return count($this->resolveA($domain, true)) > 0;
-        } catch (DNSLookupException $e) {
-            return false;
-        }
-    }
-
-    public function resetRequestCount()
-    {
-        $this->requestCount = 0;
-    }
-
-    public function countRequest()
-    {
-        if (++$this->requestCount > 10) {
-            throw new DNSLookupLimitReachedException();
-        }
-    }
-
-	public function dns_get_record($question, $type) {
-
-		$response = array();
-
-	    $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout,true,false,false);
-
-	    $result = $dnsquery->query($question,$type);
-
-	    if ($dnsquery->hasError()) {
-		    throw new \Exception("Query Error: " . $dnsquery->getLasterror());
-	    }
-
-	    foreach ($result as $index => $record) {
-
-		    $extras = array();
-
-		    // additional data
-		    if (count($record->getExtras()) > 0) {
-			    foreach ($record->getExtras() as $key => $val) {
-				    // We don't want to echo binary data
-				    if ($key != 'ipbin') {
-					    $extras[$key] = $val;
-				    }
-			    }
-		    }
-
-		    switch($type) {
-			    default:
-			    	throw new \Exception("Unsupported type " . $type . ".");
-			    	break;
-			    case "A":
-				    $response[] = array(
-					    "host" => $record->getDomain(),
-					    "class" => "IN",
-					    "ttl" => $record->getTtl(),
-					    "type" => $record->getTypeid(),
-					    "ip" => $record->getData()
-				    );
-			    	break;
-			    case "AAAA":
-				    $response[] = array(
-					    "host" => $record->getDomain(),
-					    "class" => "IN",
-					    "ttl" => $record->getTtl(),
-					    "type" => $record->getTypeid(),
-					    "ipv6" => $record->getData()
-				    );
-				    break;
-			    case "MX":
-				    $response[] = array(
-					    "host" => $record->getDomain(),
-					    "class" => "IN",
-					    "ttl" => $record->getTtl(),
-					    "type" => $record->getTypeid(),
-					    "pri" => $extras["level"],
-					    "target" => $record->getData()
-				    );
-				    break;
-			    case "TXT":
-				    $response[] = array(
-					    "host" => $record->getDomain(),
-					    "class" => "IN",
-					    "ttl" => $record->getTtl(),
-					    "type" => $record->getTypeid(),
-					    "txt" => $record->getData(),
-					    "entries" => array($record->getData())
-				    );
-				    break;
-			    case "PTR":
-				    $response[] = array(
-					    "host" => $record->getDomain(),
-					    "class" => "IN",
-					    "ttl" => $record->getTtl(),
-					    "type" => $record->getTypeid(),
-					    "target" => $record->getData()
-				    );
-				    break;
-		    }
-
-	    }
-
-	    return $response;
-    }
+	public function countRequest()
+	{
+		if (++$this->requestCount > 10) {
+			throw new DNSLookupLimitReachedException();
+		}
+	}
 }

--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -40,11 +40,11 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
      * DNSRecordGetter constructor.
      *
      * @param string $nameserver
-     * @param string $port
-     * @param string $timeout
+     * @param int $port
+     * @param int $timeout
      * @param bool $udp
      */
-    public function __construct($nameserver = "8.8.8.8", $port = "53", $timeout = "30", $udp = true)
+    public function __construct($nameserver = "8.8.8.8", $port = 53, $timeout = 30, $udp = true)
     {
         $this->nameserver = $nameserver;
         $this->port       = $port;
@@ -174,7 +174,7 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
         $result = $dnsquery->query($question, $type);
 
         if ($dnsquery->hasError()) {
-            throw new DNSLookupException;
+            throw new DNSLookupException($dnsquery->getLasterror());
         }
 
         foreach ($result as $index => $record) {

--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -11,238 +11,241 @@ use Mika56\SPFCheck\Exception\DNSLookupException;
 use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
 use PurplePixie\PhpDns\DNSQuery;
 
-class DNSRecordGetterDirect implements DNSRecordGetterInterface {
+class DNSRecordGetterDirect implements DNSRecordGetterInterface
+{
 
-	protected $requestCount = 0;
-	protected $nameserver = "8.8.8.8";
-	protected $port = 53;
-	protected $timeout = 30;
-	protected $udp = true;
+    protected $requestCount = 0;
+    protected $nameserver = "8.8.8.8";
+    protected $port = 53;
+    protected $timeout = 30;
+    protected $udp = true;
 
-	const DNS_A = 'A';
-	const DNS_CNAME = "CNAME";
-	const DNS_HINFO = "HINFO";
-	const DNS_CAA = "CAA";
-	const DNS_MX = "MX";
-	const DNS_NS = "NS";
-	const DNS_PTR = "PTR";
-	const DNS_SOA = "SOA";
-	const DNS_TXT = "TXT";
-	const DNS_AAAA = "AAAA";
-	const DNS_SRV = "SRV";
-	const DNS_NAPTR = "NAPTR";
-	const DNS_A6 = "A6";
-	const DNS_ALL = "ALL";
-	const DNS_ANY = "ANY";
+    const DNS_A = 'A';
+    const DNS_CNAME = "CNAME";
+    const DNS_HINFO = "HINFO";
+    const DNS_CAA = "CAA";
+    const DNS_MX = "MX";
+    const DNS_NS = "NS";
+    const DNS_PTR = "PTR";
+    const DNS_SOA = "SOA";
+    const DNS_TXT = "TXT";
+    const DNS_AAAA = "AAAA";
+    const DNS_SRV = "SRV";
+    const DNS_NAPTR = "NAPTR";
+    const DNS_A6 = "A6";
+    const DNS_ALL = "ALL";
+    const DNS_ANY = "ANY";
 
-	/**
-	 * DNSRecordGetter constructor.
-	 *
-	 * @param string $nameserver
-	 * @param string $port
-	 * @param string $timeout
-	 */
-	public function __construct($nameserver = "8.8.8.8", $port = "53", $timeout = "30", $udp = true) {
-		$this->nameserver = $nameserver;
-		$this->port = $port;
-		$this->timeout = $timeout;
-		$this->udp = $udp;
-	}
+    /**
+     * DNSRecordGetter constructor.
+     *
+     * @param string $nameserver
+     * @param string $port
+     * @param string $timeout
+     * @param bool $udp
+     */
+    public function __construct($nameserver = "8.8.8.8", $port = "53", $timeout = "30", $udp = true)
+    {
+        $this->nameserver = $nameserver;
+        $this->port       = $port;
+        $this->timeout    = $timeout;
+        $this->udp        = $udp;
+    }
 
-	/**
-	 * @param $domain string The domain to get SPF record
-	 * @return string[] The SPF record(s)
-	 * @throws DNSLookupException
-	 */
-	public function getSPFRecordForDomain($domain)
-	{
-		$records = $this->dns_get_record($domain, "TXT");
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+    /**
+     * @param $domain string The domain to get SPF record
+     * @return string[] The SPF record(s)
+     * @throws DNSLookupException
+     */
+    public function getSPFRecordForDomain($domain)
+    {
+        $records = $this->dns_get_record($domain, "TXT");
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-		$spfRecords = array();
-		foreach ($records as $record) {
-			if ($record['type'] == 'TXT') {
-				$txt = strtolower($record['txt']);
-				// An SPF record can be empty (no mechanism)
-				if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
-					$spfRecords[] = $txt;
-				}
-			}
-		}
+        $spfRecords = array();
+        foreach ($records as $record) {
+            if ($record['type'] == 'TXT') {
+                $txt = strtolower($record['txt']);
+                // An SPF record can be empty (no mechanism)
+                if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
+                    $spfRecords[] = $txt;
+                }
+            }
+        }
 
-		return $spfRecords;
-	}
+        return $spfRecords;
+    }
 
-	public function resolveA($domain, $ip4only = false)
-	{
+    public function resolveA($domain, $ip4only = false)
+    {
+        $records = $this->dns_get_record($domain, "A");
 
-		$records = $this->dns_get_record($domain, "A");
+        if (!$ip4only) {
+            $ip6 = $this->dns_get_record($domain, "AAAA");
+            if ($ip6) {
+                $records = array_merge($records, $ip6);
+            }
+        }
 
-		if(!$ip4only) {
-			$ip6 = $this->dns_get_record($domain, "AAAA");
-			if($ip6) {
-				$records = array_merge($records,$ip6);
-			}
-		}
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+        $addresses = [];
 
-		$addresses = [];
+        foreach ($records as $record) {
+            if ($record['type'] === "A") {
+                $addresses[] = $record['ip'];
+            } elseif ($record['type'] === 'AAAA') {
+                $addresses[] = $record['ipv6'];
+            }
+        }
 
-		foreach ($records as $record) {
-			if ($record['type'] === "A") {
-				$addresses[] = $record['ip'];
-			} elseif ($record['type'] === 'AAAA') {
-				$addresses[] = $record['ipv6'];
-			}
-		}
+        return $addresses;
+    }
 
-		return $addresses;
-	}
+    public function resolveMx($domain)
+    {
+        $records = $this->dns_get_record($domain, "MX");
+        if (false === $records) {
+            throw new DNSLookupException;
+        }
 
-	public function resolveMx($domain)
-	{
-		$records = $this->dns_get_record($domain, "MX");
-		if (false === $records) {
-			throw new DNSLookupException;
-		}
+        $addresses = [];
 
-		$addresses = [];
+        foreach ($records as $record) {
+            if ($record['type'] === "MX") {
+                $addresses[] = $record['target'];
+            }
+        }
 
-		foreach ($records as $record) {
-			if ($record['type'] === "MX") {
-				$addresses[] = $record['target'];
-			}
-		}
+        return $addresses;
+    }
 
-		return $addresses;
-	}
+    public function resolvePtr($ipAddress)
+    {
+        if (stripos($ipAddress, '.') !== false) {
+            // IPv4
+            $revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
+        } else {
+            $literal = implode(':', array_map(function ($b) {
+                return sprintf('%04x', $b);
+            }, unpack('n*', inet_pton($ipAddress))));
+            $revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
+        }
 
-	public function resolvePtr($ipAddress)
-	{
-		if (stripos($ipAddress, '.') !== false) {
-			// IPv4
-			$revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
-		} else {
-			$literal = implode(':', array_map(function ($b) {
-				return sprintf('%04x', $b);
-			}, unpack('n*', inet_pton($ipAddress))));
-			$revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
-		}
+        $revs = array_map(function ($e) {
+            return $e['target'];
+        }, dns_get_record($revIp, "PTR"));
 
-		$revs = array_map(function ($e) {
-			return $e['target'];
-		}, dns_get_record($revIp, "PTR"));
+        return array_slice($revs, 0, 10);
+    }
 
-		return array_slice($revs, 0, 10);
-	}
+    public function exists($domain)
+    {
+        try {
+            return count($this->resolveA($domain, true)) > 0;
+        } catch (DNSLookupException $e) {
+            return false;
+        }
+    }
 
-	public function exists($domain)
-	{
-		try {
-			return count($this->resolveA($domain, true)) > 0;
-		} catch (DNSLookupException $e) {
-			return false;
-		}
-	}
+    public function resetRequestCount()
+    {
+        $this->requestCount = 0;
+    }
 
-	public function resetRequestCount()
-	{
-		$this->requestCount = 0;
-	}
+    public function countRequest()
+    {
+        if (++$this->requestCount > 10) {
+            throw new DNSLookupLimitReachedException();
+        }
+    }
 
-	public function countRequest()
-	{
-		if (++$this->requestCount > 10) {
-			throw new DNSLookupLimitReachedException();
-		}
-	}
+    public function dns_get_record($question, $type)
+    {
 
-	public function dns_get_record($question, $type) {
+        $response = array();
 
-		$response = array();
+        $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout, true, false, false);
 
-		$dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout,true,false,false);
+        $result = $dnsquery->query($question, $type);
 
-		$result = $dnsquery->query($question,$type);
+        if ($dnsquery->hasError()) {
+            throw new DNSLookupException;
+        }
 
-		if ($dnsquery->hasError()) {
-			throw new DNSLookupException;
-		}
+        foreach ($result as $index => $record) {
 
-		foreach ($result as $index => $record) {
+            $extras = array();
 
-			$extras = array();
+            // additional data
+            if (count($record->getExtras()) > 0) {
+                foreach ($record->getExtras() as $key => $val) {
+                    // We don't want to echo binary data
+                    if ($key != 'ipbin') {
+                        $extras[$key] = $val;
+                    }
+                }
+            }
 
-			// additional data
-			if (count($record->getExtras()) > 0) {
-				foreach ($record->getExtras() as $key => $val) {
-					// We don't want to echo binary data
-					if ($key != 'ipbin') {
-						$extras[$key] = $val;
-					}
-				}
-			}
+            switch ($type) {
+                default:
+                    throw new \Exception("Unsupported type ".$type.".");
+                    break;
+                case "A":
+                    $response[] = array(
+                        "host"  => $record->getDomain(),
+                        "class" => "IN",
+                        "ttl"   => $record->getTtl(),
+                        "type"  => $record->getTypeid(),
+                        "ip"    => $record->getData(),
+                    );
+                    break;
+                case "AAAA":
+                    $response[] = array(
+                        "host"  => $record->getDomain(),
+                        "class" => "IN",
+                        "ttl"   => $record->getTtl(),
+                        "type"  => $record->getTypeid(),
+                        "ipv6"  => $record->getData(),
+                    );
+                    break;
+                case "MX":
+                    $response[] = array(
+                        "host"   => $record->getDomain(),
+                        "class"  => "IN",
+                        "ttl"    => $record->getTtl(),
+                        "type"   => $record->getTypeid(),
+                        "pri"    => $extras["level"],
+                        "target" => $record->getData(),
+                    );
+                    break;
+                case "TXT":
+                    $response[] = array(
+                        "host"    => $record->getDomain(),
+                        "class"   => "IN",
+                        "ttl"     => $record->getTtl(),
+                        "type"    => $record->getTypeid(),
+                        "txt"     => $record->getData(),
+                        "entries" => array($record->getData()),
+                    );
+                    break;
+                case "PTR":
+                    $response[] = array(
+                        "host"   => $record->getDomain(),
+                        "class"  => "IN",
+                        "ttl"    => $record->getTtl(),
+                        "type"   => $record->getTypeid(),
+                        "target" => $record->getData(),
+                    );
+                    break;
+            }
 
-			switch($type) {
-				default:
-					throw new \Exception("Unsupported type " . $type . ".");
-					break;
-				case "A":
-					$response[] = array(
-						"host" => $record->getDomain(),
-						"class" => "IN",
-						"ttl" => $record->getTtl(),
-						"type" => $record->getTypeid(),
-						"ip" => $record->getData()
-					);
-					break;
-				case "AAAA":
-					$response[] = array(
-						"host" => $record->getDomain(),
-						"class" => "IN",
-						"ttl" => $record->getTtl(),
-						"type" => $record->getTypeid(),
-						"ipv6" => $record->getData()
-					);
-					break;
-				case "MX":
-					$response[] = array(
-						"host" => $record->getDomain(),
-						"class" => "IN",
-						"ttl" => $record->getTtl(),
-						"type" => $record->getTypeid(),
-						"pri" => $extras["level"],
-						"target" => $record->getData()
-					);
-					break;
-				case "TXT":
-					$response[] = array(
-						"host" => $record->getDomain(),
-						"class" => "IN",
-						"ttl" => $record->getTtl(),
-						"type" => $record->getTypeid(),
-						"txt" => $record->getData(),
-						"entries" => array($record->getData())
-					);
-					break;
-				case "PTR":
-					$response[] = array(
-						"host" => $record->getDomain(),
-						"class" => "IN",
-						"ttl" => $record->getTtl(),
-						"type" => $record->getTypeid(),
-						"target" => $record->getData()
-					);
-					break;
-			}
+        }
 
-		}
-
-		return $response;
-	}
+        return $response;
+    }
 }

--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * DNSRecordGetterDirect
+ *
+ * @author    Brian Tafoya <btafoya@briantafoya.com>
+ */
+
+namespace Mika56\SPFCheck;
+
+use Mika56\SPFCheck\Exception\DNSLookupException;
+use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
+use PurplePixie\PhpDns\DNSQuery;
+
+class DNSRecordGetterDirect implements DNSRecordGetterInterface {
+
+	protected $requestCount = 0;
+	protected $nameserver = "8.8.8.8";
+	protected $port = 53;
+	protected $timeout = 30;
+	protected $udp = true;
+
+	const DNS_A = 'A';
+	const DNS_CNAME = "CNAME";
+	const DNS_HINFO = "HINFO";
+	const DNS_CAA = "CAA";
+	const DNS_MX = "MX";
+	const DNS_NS = "NS";
+	const DNS_PTR = "PTR";
+	const DNS_SOA = "SOA";
+	const DNS_TXT = "TXT";
+	const DNS_AAAA = "AAAA";
+	const DNS_SRV = "SRV";
+	const DNS_NAPTR = "NAPTR";
+	const DNS_A6 = "A6";
+	const DNS_ALL = "ALL";
+	const DNS_ANY = "ANY";
+
+	/**
+	 * DNSRecordGetter constructor.
+	 *
+	 * @param string $nameserver
+	 * @param string $port
+	 * @param string $timeout
+	 */
+	public function __construct($nameserver = "8.8.8.8", $port = "53", $timeout = "30", $udp = true) {
+		$this->nameserver = $nameserver;
+		$this->port = $port;
+		$this->timeout = $timeout;
+		$this->udp = $udp;
+	}
+
+	/**
+	 * @param $domain string The domain to get SPF record
+	 * @return string[] The SPF record(s)
+	 * @throws DNSLookupException
+	 */
+	public function getSPFRecordForDomain($domain)
+	{
+		$records = $this->dns_get_record($domain, "TXT");
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
+
+		$spfRecords = array();
+		foreach ($records as $record) {
+			if ($record['type'] == 'TXT') {
+				$txt = strtolower($record['txt']);
+				// An SPF record can be empty (no mechanism)
+				if ($txt == 'v=spf1' || stripos($txt, 'v=spf1 ') === 0) {
+					$spfRecords[] = $txt;
+				}
+			}
+		}
+
+		return $spfRecords;
+	}
+
+	public function resolveA($domain, $ip4only = false)
+	{
+
+		$records = $this->dns_get_record($domain, "A");
+
+		if(!$ip4only) {
+			$ip6 = $this->dns_get_record($domain, "AAAA");
+			if($ip6) {
+				$records = array_merge($records,$ip6);
+			}
+		}
+
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
+
+		$addresses = [];
+
+		foreach ($records as $record) {
+			if ($record['type'] === "A") {
+				$addresses[] = $record['ip'];
+			} elseif ($record['type'] === 'AAAA') {
+				$addresses[] = $record['ipv6'];
+			}
+		}
+
+		return $addresses;
+	}
+
+	public function resolveMx($domain)
+	{
+		$records = $this->dns_get_record($domain, "MX");
+		if (false === $records) {
+			throw new DNSLookupException;
+		}
+
+		$addresses = [];
+
+		foreach ($records as $record) {
+			if ($record['type'] === "MX") {
+				$addresses[] = $record['target'];
+			}
+		}
+
+		return $addresses;
+	}
+
+	public function resolvePtr($ipAddress)
+	{
+		if (stripos($ipAddress, '.') !== false) {
+			// IPv4
+			$revIp = implode('.', array_reverse(explode('.', $ipAddress))).'.in-addr.arpa';
+		} else {
+			$literal = implode(':', array_map(function ($b) {
+				return sprintf('%04x', $b);
+			}, unpack('n*', inet_pton($ipAddress))));
+			$revIp   = strtolower(implode('.', array_reverse(str_split(str_replace(':', '', $literal))))).'.ip6.arpa';
+		}
+
+		$revs = array_map(function ($e) {
+			return $e['target'];
+		}, dns_get_record($revIp, "PTR"));
+
+		return array_slice($revs, 0, 10);
+	}
+
+	public function exists($domain)
+	{
+		try {
+			return count($this->resolveA($domain, true)) > 0;
+		} catch (DNSLookupException $e) {
+			return false;
+		}
+	}
+
+	public function resetRequestCount()
+	{
+		$this->requestCount = 0;
+	}
+
+	public function countRequest()
+	{
+		if (++$this->requestCount > 10) {
+			throw new DNSLookupLimitReachedException();
+		}
+	}
+
+	public function dns_get_record($question, $type) {
+
+		$response = array();
+
+		$dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout,true,false,false);
+
+		$result = $dnsquery->query($question,$type);
+
+		if ($dnsquery->hasError()) {
+			throw new DNSLookupException;
+		}
+
+		foreach ($result as $index => $record) {
+
+			$extras = array();
+
+			// additional data
+			if (count($record->getExtras()) > 0) {
+				foreach ($record->getExtras() as $key => $val) {
+					// We don't want to echo binary data
+					if ($key != 'ipbin') {
+						$extras[$key] = $val;
+					}
+				}
+			}
+
+			switch($type) {
+				default:
+					throw new \Exception("Unsupported type " . $type . ".");
+					break;
+				case "A":
+					$response[] = array(
+						"host" => $record->getDomain(),
+						"class" => "IN",
+						"ttl" => $record->getTtl(),
+						"type" => $record->getTypeid(),
+						"ip" => $record->getData()
+					);
+					break;
+				case "AAAA":
+					$response[] = array(
+						"host" => $record->getDomain(),
+						"class" => "IN",
+						"ttl" => $record->getTtl(),
+						"type" => $record->getTypeid(),
+						"ipv6" => $record->getData()
+					);
+					break;
+				case "MX":
+					$response[] = array(
+						"host" => $record->getDomain(),
+						"class" => "IN",
+						"ttl" => $record->getTtl(),
+						"type" => $record->getTypeid(),
+						"pri" => $extras["level"],
+						"target" => $record->getData()
+					);
+					break;
+				case "TXT":
+					$response[] = array(
+						"host" => $record->getDomain(),
+						"class" => "IN",
+						"ttl" => $record->getTtl(),
+						"type" => $record->getTypeid(),
+						"txt" => $record->getData(),
+						"entries" => array($record->getData())
+					);
+					break;
+				case "PTR":
+					$response[] = array(
+						"host" => $record->getDomain(),
+						"class" => "IN",
+						"ttl" => $record->getTtl(),
+						"type" => $record->getTypeid(),
+						"target" => $record->getData()
+					);
+					break;
+			}
+
+		}
+
+		return $response;
+	}
+}

--- a/test.php
+++ b/test.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: btafoya
+ * Date: 8/10/17
+ * Time: 7:04 PM
+ */
+
+include ("vendor/autoload.php");
+
+$test = new \Mika56\SPFCheck\DNSRecordGetterDirect("8.8.8.8");
+
+print_r($test->dns_get_record("google.com", "MX"));
+
+print_r(dns_get_record("google.com", DNS_MX));

--- a/tests/DNSRecordGetterDirectTest.php
+++ b/tests/DNSRecordGetterDirectTest.php
@@ -23,24 +23,6 @@ class DNSRecordGetterDirectTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($result);
     }
 
-    public function testResolveA()
-    {
-
-        $dnsRecordGetter = new DNSRecordGetterDirect();
-
-        $result = $dnsRecordGetter->resolveA('google.com', true);
-        $this->assertContains('74.125.196.139', $result);
-        $this->assertNotContains('::12', $result);
-
-        /*
-         * Google responds with different ip6 data, so really not a good test case.
-         *
-        $result = $dnsRecordGetter->resolveA('google.com', false);
-        $this->assertContains('74.125.196.139', $result);
-        $this->assertContains('2607:f8b0:4002:c07::8a', $result);
-        */
-    }
-
     public function testResolveMx()
     {
 

--- a/tests/DNSRecordGetterDirectTest.php
+++ b/tests/DNSRecordGetterDirectTest.php
@@ -7,33 +7,124 @@
 
 namespace Mika56\SPFCheck;
 
-
+/**
+ * @covers \Mika56\SPFCheck\DNSRecordGetterDirect
+ */
 class DNSRecordGetterDirectTest extends \PHPUnit_Framework_TestCase
 {
+    private $dnsServer = '127.0.0.1';
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        if (array_key_exists('DNS_SERVER', $_ENV)) {
+            $this->dnsServer = $_ENV['DNS_SERVER'];
+        }
+    }
+
+    public function setUp()
+    {
+        // Ensure DNS server has no entries
+        $this->tearDown();
+
+        $postdata = [
+            'name'        => 'test.local.dev',
+            'kind'        => 'Native',
+            'masters'     => [],
+            'nameservers' => ['ns1.test.local.dev', 'ns2.test.local.dev',],
+        ];
+
+        $this->dnsApi('servers/localhost/zones', 'POST', $postdata);
+
+        $postdata = [
+            'rrsets' => [
+                [
+                    'name'       => 'test.local.dev',
+                    'type'       => 'TXT',
+                    'ttl'        => 86400,
+                    'changetype' => 'REPLACE',
+                    'records'    => [
+                        [
+                            'content'  => '"notaspf"',
+                            'disabled' => false,
+                            'name'     => 'test.local.dev',
+                            'type'     => 'TXT',
+                            'ttl'      => 86400,
+                            'priority' => 0,
+                        ],
+                        [
+                            'content'  => '"v=spf1 a -all"',
+                            'disabled' => false,
+                            'name'     => 'test.local.dev',
+                            'type'     => 'TXT',
+                            'ttl'      => 86400,
+                            'priority' => 1,
+                        ],
+                    ],
+                ],
+                [
+                    'name'       => 'test.local.dev',
+                    'type'       => 'MX',
+                    'ttl'        => 86400,
+                    'changetype' => 'REPLACE',
+                    'records'    => [
+                        [
+                            'content'  => 'smtp.test.local.dev',
+                            'disabled' => false,
+                            'name'     => 'test.local.dev',
+                            'type'     => 'MX',
+                            'ttl'      => 86400,
+                            'priority' => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dnsApi('servers/localhost/zones/test.local.dev.', 'PATCH', $postdata);
+    }
+
     public function testGetSPFRecordForDomain()
     {
+        $dnsRecordGetter = new DNSRecordGetterDirect($this->dnsServer, 53, 3, false);
 
-        $dnsRecordGetter = new DNSRecordGetterDirect();
-
-        $result = $dnsRecordGetter->getSPFRecordForDomain('google.com');
+        $result = $dnsRecordGetter->getSPFRecordForDomain('test.local.dev');
         $this->assertCount(1, $result);
-        $this->assertContains('v=spf1 include:_spf.google.com ~all', $result);
+        $this->assertContains('v=spf1 a -all', $result);
 
-        $result = $dnsRecordGetter->getSPFRecordForDomain('doesnotexistgoogle.com');
+        $result = $dnsRecordGetter->getSPFRecordForDomain('noexist.local.dev');
         $this->assertEmpty($result);
     }
 
     public function testResolveMx()
     {
+        $dnsRecordGetter = new DNSRecordGetterDirect($this->dnsServer);
 
+        $result = $dnsRecordGetter->resolveMx('test.local.dev');
+        $this->assertCount(1, $result);
+        $this->assertContains('smtp.test.local.dev', $result);
 
-        $dnsRecordGetter = new DNSRecordGetterDirect();
-
-        $result = $dnsRecordGetter->resolveMx('google.com');
-        $this->assertCount(5, $result);
-        $this->assertContains('alt3.aspmx.l.google.com', $result);
-
-        $result = $dnsRecordGetter->resolveMx('example2.com');
+        $result = $dnsRecordGetter->resolveMx('noexist.local.dev');
         $this->assertCount(0, $result);
+    }
+
+    public function tearDown()
+    {
+        @$this->dnsApi('servers/localhost/zones/test.local.dev', 'DELETE');
+    }
+
+    private function dnsApi($url, $method, $data = [])
+    {
+        $opts = [
+            'http' => [
+                'method'  => $method,
+                'header'  => 'Content-type: application/json'."\r\n".'X-API-Key: password'."\r\n",
+                'content' => json_encode($data),
+            ],
+        ];
+
+        $context = stream_context_create($opts);
+
+        return file_get_contents('http://'.$this->dnsServer.':80/'.$url, false, $context);
     }
 }

--- a/tests/DNSRecordGetterDirectTest.php
+++ b/tests/DNSRecordGetterDirectTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * DNSRecordGetterDirectTest - phpUnit Test
+ *
+ * @author    Brian Tafoya <btafoya@briantafoya.com>
+ */
+
+namespace Mika56\SPFCheck;
+
+
+class DNSRecordGetterDirectTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSPFRecordForDomain()
+    {
+
+        $dnsRecordGetter = new DNSRecordGetterDirect();
+
+        $result = $dnsRecordGetter->getSPFRecordForDomain('google.com');
+        $this->assertCount(1, $result);
+        $this->assertContains('v=spf1 include:_spf.google.com ~all', $result);
+
+        $result = $dnsRecordGetter->getSPFRecordForDomain('doesnotexistgoogle.com');
+        $this->assertEmpty($result);
+    }
+
+    public function testResolveA()
+    {
+
+        $dnsRecordGetter = new DNSRecordGetterDirect();
+
+        $result = $dnsRecordGetter->resolveA('google.com', true);
+        $this->assertContains('74.125.196.139', $result);
+        $this->assertNotContains('::12', $result);
+
+        /*
+         * Google responds with different ip6 data, so really not a good test case.
+         *
+        $result = $dnsRecordGetter->resolveA('google.com', false);
+        $this->assertContains('74.125.196.139', $result);
+        $this->assertContains('2607:f8b0:4002:c07::8a', $result);
+        */
+    }
+
+    public function testResolveMx()
+    {
+
+
+        $dnsRecordGetter = new DNSRecordGetterDirect();
+
+        $result = $dnsRecordGetter->resolveMx('google.com');
+        $this->assertCount(5, $result);
+        $this->assertContains('alt3.aspmx.l.google.com', $result);
+
+        $result = $dnsRecordGetter->resolveMx('example2.com');
+        $this->assertCount(0, $result);
+    }
+}


### PR DESCRIPTION
Added PHP DNS Direct Query Module (https://github.com/purplepixie/phpdns) to add the ability to specify the nameserver to query for the results.