### PR TITLE
Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.0
   - 7.1
   - nightly
-  - hhvm
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ php:
   - nightly
 
 matrix:
+  fast_finish: true
   allow_failures:
-    - nightly
+    - php: nightly
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # PHP-SPF-Check
 [![Build Status](https://travis-ci.org/Mika56/PHP-SPF-Check.svg?branch=master)](https://travis-ci.org/Mika56/PHP-SPF-Check)
-[![HHVM](https://img.shields.io/hhvm/mika56/spfcheck.svg?maxAge=2592000)](http://hhvm.h4cc.de/package/mika56/spfcheck)
 [![Latest Stable Version](https://poser.pugx.org/mika56/spfcheck/v/stable)](https://packagist.org/packages/mika56/spfcheck)
 [![Total Downloads](https://poser.pugx.org/mika56/spfcheck/downloads)](https://packagist.org/packages/mika56/spfcheck)
 [![License](https://poser.pugx.org/mika56/spfcheck/license)](https://packagist.org/packages/mika56/spfcheck)


### PR DESCRIPTION
HHVM was abandoned by a lot of PHP projects. Considering building does not even work, this will drop HHVM support