### PR TITLE
Two bugfixes for the DNSRecordGetterDirect class.

### DIFF
--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -138,7 +138,7 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
 
         $revs = array_map(function ($e) {
             return $e['target'];
-        }, dns_get_record($revIp, "PTR"));
+        }, $this->dns_get_record($revIp, "PTR"));
 
         return array_slice($revs, 0, 10);
     }
@@ -169,7 +169,7 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
 
         $response = array();
 
-        $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout, true, false, false);
+        $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout, $this->udp, false, false);
 
         $result = $dnsquery->query($question, $type);
 


### PR DESCRIPTION
First one: it is not properly using TCP when asked to do so. The reason is that it is not passing $this->udp to the DNSQuery.

Second: resolvePtr method is using the SPL implementation of dns_get_record instead of using the class' implementation.