### PR TITLE
PHPDoc compatibility

### DIFF
--- a/src/DNSRecordGetter.php
+++ b/src/DNSRecordGetter.php
@@ -17,7 +17,7 @@ class DNSRecordGetter implements DNSRecordGetterInterface
     protected $requestPTRCount = 0;
 
     /**
-     * @param $domain string The domain to get SPF record
+     * @param string $domain The domain to get SPF record
      * @return string[] The SPF record(s)
      * @throws DNSLookupException
      */

--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -55,7 +55,7 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
     }
 
     /**
-     * @param $domain string The domain to get SPF record
+     * @param string $domain The domain to get SPF record
      * @return string[] The SPF record(s)
      * @throws DNSLookupException
      */

--- a/src/SPFCheck.php
+++ b/src/SPFCheck.php
@@ -93,9 +93,9 @@ class SPFCheck
     }
 
     /**
-     * @param $ipAddress
-     * @param $domain
-     * @return bool|string
+     * @param string $ipAddress
+     * @param string $domain
+     * @return string|false
      * @throws DNSLookupException
      */
     private function doCheck($ipAddress, $domain)
@@ -148,10 +148,10 @@ class SPFCheck
     }
 
     /**
-     * @param $ipAddress
-     * @param $part
-     * @param $matchingDomain
-     * @return bool
+     * @param string $ipAddress
+     * @param string $part
+     * @param string $matchingDomain
+     * @return string|false
      * @throws DNSLookupLimitReachedException
      * @throws DNSLookupException
      */


### PR DESCRIPTION
These notations are not warned by PhpStorm, but they enhance interoperability with other static analyzers.