### PR TITLE
retry with tcp if upd fails

### DIFF
--- a/src/DNSRecordGetterDirect.php
+++ b/src/DNSRecordGetterDirect.php
@@ -21,6 +21,7 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
     protected $port = 53;
     protected $timeout = 30;
     protected $udp = true;
+    protected $tcpFallback;
 
     const DNS_A = 'A';
     const DNS_CNAME = "CNAME";
@@ -45,13 +46,15 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
      * @param int $port
      * @param int $timeout
      * @param bool $udp
+     * @param bool $tcpFallback
      */
-    public function __construct($nameserver = "8.8.8.8", $port = 53, $timeout = 30, $udp = true)
+    public function __construct($nameserver = "8.8.8.8", $port = 53, $timeout = 30, $udp = true, $tcpFallback = true)
     {
-        $this->nameserver = $nameserver;
-        $this->port       = $port;
-        $this->timeout    = $timeout;
-        $this->udp        = $udp;
+        $this->nameserver  = $nameserver;
+        $this->port        = $port;
+        $this->timeout     = $timeout;
+        $this->udp         = $udp;
+        $this->tcpFallback = $tcpFallback;
     }
 
     /**
@@ -156,21 +159,20 @@ class DNSRecordGetterDirect implements DNSRecordGetterInterface
 
     public function dns_get_record($question, $type)
     {
-
         $response = array();
 
         $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout, $this->udp, false, false);
-        $result = $dnsquery->query($question, $type);
+        $result   = $dnsquery->query($question, $type);
 
         // Retry if we get an too big for UDP error
-        if ($dnsquery->hasError() && $dnsquery->getLasterror() == "Response too big for UDP, retry with TCP")  {
+        if ($this->udp && $this->tcpFallback && $dnsquery->hasError() && $dnsquery->getLasterror() == "Response too big for UDP, retry with TCP") {
             $dnsquery = new DNSQuery($this->nameserver, (int)$this->port, (int)$this->timeout, false, false, false);
-            $result = $dnsquery->query($question, $type);
+            $result   = $dnsquery->query($question, $type);
         }
 
-        if($dnsquery->hasError()){
+        if ($dnsquery->hasError()) {
             throw new DNSLookupException($dnsquery->getLasterror());
-        } 
+        }
 
         foreach ($result as $index => $record) {
 

--- a/tests/Pull34Test.php
+++ b/tests/Pull34Test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ *
+ * @author Mikael Peigney
+ */
+
+namespace Mika56\SPFCheck;
+
+/**
+ * This tests ensures that when a DNS query fails with UDP, it is retried with TCP
+ * TXT records might be too long to fit inside an UDP packet
+ */
+class Pull34Test extends \PHPUnit_Framework_TestCase
+{
+    private $dnsServer = '127.0.0.1';
+    private $zonesToCreate = [
+        'myloooooooooooooooooooooooooooooooooongfirstprovider.com',
+        'myloooooooooooooooooooooooooooooooooongsecondprovider.com',
+        'myloooooooooooooooooooooooooooooooooongthirdprovider.com',
+        'myloooooooooooooooooooooooooooooooooongfourthprovider.com',
+        'myloooooooooooooooooooooooooooooooooongfifthprovider.com',
+        'myloooooooooooooooooooooooooooooooooongsixthprovider.com',
+        'myloooooooooooooooooooooooooooooooooongseventhprovider.com',
+        'myloooooooooooooooooooooooooooooooooongeightprovider.com',
+        'myloooooooooooooooooooooooooooooooooongninthprovider.com',
+    ];
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        if (array_key_exists('DNS_SERVER', $_ENV)) {
+            $this->dnsServer = $_ENV['DNS_SERVER'];
+        }
+    }
+
+    public function testPull34()
+    {
+        // UDP with TCP fallback
+        $dnsRecordGetter = new DNSRecordGetterDirect($this->dnsServer, 53, 3);
+        $SPFCheck        = new SPFCheck($dnsRecordGetter);
+        $this->assertEquals(SPFCheck::RESULT_PASS, $SPFCheck->isIPAllowed('127.0.0.1', 'test.local.dev'));
+
+        // TCP only
+        $dnsRecordGetter = new DNSRecordGetterDirect($this->dnsServer, 53, 3, false);
+        $SPFCheck        = new SPFCheck($dnsRecordGetter);
+        $this->assertEquals(SPFCheck::RESULT_PASS, $SPFCheck->isIPAllowed('127.0.0.1', 'test.local.dev'));
+
+        // UDP only
+        $dnsRecordGetter = new DNSRecordGetterDirect($this->dnsServer, 53, 3, true, false);
+        $SPFCheck        = new SPFCheck($dnsRecordGetter);
+        $this->assertEquals(SPFCheck::RESULT_TEMPERROR, $SPFCheck->isIPAllowed('127.0.0.1', 'test.local.dev'));
+    }
+
+    public function setUp()
+    {
+        // Ensure DNS server has no entries
+        $this->tearDown();
+
+        foreach ($this->zonesToCreate as $zone) {
+            $this->createZone($zone);
+        }
+        $this->createZone('test.local.dev');
+
+        $postdata = [
+            'rrsets' => [
+                [
+                    'name'       => 'test.local.dev',
+                    'type'       => 'TXT',
+                    'ttl'        => 86400,
+                    'changetype' => 'REPLACE',
+                    'records'    => [
+                        [
+                            'content'  => '"v=spf1 a ip4:10.0.0.0/8 include='.implode(' include=', $this->zonesToCreate).' ip4:127.0.0.1 -all"',
+                            'disabled' => false,
+                            'name'     => 'test.local.dev',
+                            'type'     => 'TXT',
+                            'ttl'      => 86400,
+                            'priority' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dnsApi('servers/localhost/zones/test.local.dev.', 'PATCH', $postdata);
+    }
+
+    public function tearDown()
+    {
+        foreach ($this->zonesToCreate as $zone) {
+            @$this->dnsApi('servers/localhost/zones/'.$zone, 'DELETE');
+        }
+        @$this->dnsApi('servers/localhost/zones/test.local.dev', 'DELETE');
+    }
+
+    private function dnsApi($url, $method, $data = [])
+    {
+        $opts = [
+            'http' => [
+                'method'  => $method,
+                'header'  => 'Content-type: application/json'."\r\n".'X-API-Key: password'."\r\n",
+                'content' => json_encode($data),
+            ],
+        ];
+
+        $context = stream_context_create($opts);
+
+        return file_get_contents('http://'.$this->dnsServer.':80/'.$url, false, $context);
+    }
+
+    private function createZone($zone)
+    {
+        $postdata = [
+            'name'        => $zone,
+            'kind'        => 'Native',
+            'masters'     => [],
+            'nameservers' => ['ns1.'.$zone, 'ns2.'.$zone,],
+        ];
+
+        $this->dnsApi('servers/localhost/zones', 'POST', $postdata);
+
+        if ($zone !== 'test.local.dev') {
+            $postdata = [
+                'rrsets' => [
+                    [
+                        'name'       => $zone,
+                        'type'       => 'TXT',
+                        'ttl'        => 86400,
+                        'changetype' => 'REPLACE',
+                        'records'    => [
+                            [
+                                'content'  => '"v=spf1 ?all"',
+                                'disabled' => false,
+                                'name'     => $zone,
+                                'type'     => 'TXT',
+                                'ttl'      => 86400,
+                                'priority' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $this->dnsApi('servers/localhost/zones/'.$zone.'.', 'PATCH', $postdata);
+        }
+    }
+}


### PR DESCRIPTION
dns_get_record throws an exception in some cases when domains have large SPF records.  The PR adds a retry using TCP if UDP fails.  

An example of how to trigger the UDP too large exception:

$checker = new SPFCheck(new DNSRecordGetterDirect("8.8.8.8")); 
var_dump($checker->isIPAllowed('127.0.0.1', 'higherground.it'));