### PR TITLE
Provide example SPF Cache code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 
 Simple library to check an IP address against a domain's [SPF](http://www.openspf.org/) record
 
+This is an updated fork of `mika56/spfcheck`, with only minor changes.
+
 ## Installation
 This library is available through Composer.
-Run `composer require mika56/spfcheck` or add this to your composer.json:
+Run `composer require xrobau/spfcheck` or add this to your composer.json:
 ```json
 {
   "require": {
-    "mika56/spfcheck": "^1"
+    "xrobau/spfcheck": "^1"
   }
 }
 ```

--- a/cache/2020_08_17_012703_create_spf_dns_cache.php
+++ b/cache/2020_08_17_012703_create_spf_dns_cache.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Laravel Migration to create SPF DNS Cache
+ *
+ * Copyright 2020 Rob Thomas <xrobau@gmail.com>
+ *
+ * @licence MIT
+ */
+class CreateSpfDnsCache extends Migration
+{
+    /**
+     * Create our dns cache table
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('spf_dns_cache', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('validuntil');
+            $table->char('domainname', 200);
+            $table->char('parentdomain');
+            $table->boolean('iswildcard')->default(0);
+            $table->integer('txtrownum')->default(0);
+            $table->text('txtvalue');
+            $table->index(['domainname', 'parentdomain', 'iswildcard', 'validuntil'], 'mainidx');
+            $table->index('validuntil');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('spf_dns_cache');
+    }
+}

--- a/cache/DNSRecordGetterFromCache.php
+++ b/cache/DNSRecordGetterFromCache.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App;
+
+use App\Models\SpfDnsCache;
+use Mika56\SPFCheck\DNSRecordGetter;
+use Mika56\SPFCheck\Exception\DNSLookupLimitReachedException;
+
+/**
+ * Cache implementation
+ *
+ * NOTE THIS NOT COMPLIANT WITH THE SPF STANDARD AS IT ALLOWS
+ * MORE THAN 10 LOOKUPS.
+ *
+ * If you care, fix the max lookup variables below.
+ *
+ * Copyright 2020 Rob Thomas <xrobau@gmail.com>
+ *
+ * @licence MIT
+ */
+
+class DNSRecordGetterFromCache extends DNSRecordGetter
+{
+    private $maxmx = 20;
+    private $maxptr = 20;
+    private $maxrequest = 20;
+
+    public function getSPFRecordForDomain($domain)
+    {
+        $cache = SpfDnsCache::getTxtRecords($domain);
+        if ($cache['found']) {
+            return $cache['records'];
+        }
+
+        // We don't have it cached, grab it from our parent
+        $records = parent::getSPFRecordForDomain($domain);
+        // If there's no records, only cache for 1 hour, otherwise cache for default
+        if (!$records) {
+            $expiry = new \DateInterval('PT1H');
+        } else {
+            $expiry = null;
+        }
+        SpfDnsCache::addEntry($domain, $records, false, $expiry);
+        return $records;
+    }
+
+    public function countMxRequest()
+    {
+        if ($this->requestMXCount++ >= $this->maxmx) {
+            throw new DNSLookupLimitReachedException();
+        }
+    }
+
+    public function countPtrRequest()
+    {
+        if ($this->requestPTRCount++ >= $this->maxptr) {
+            throw new DNSLookupLimitReachedException();
+        }
+    }
+    public function countRequest()
+    {
+        if ($this->requestCount++ >= $this->maxrequest) {
+            throw new DNSLookupLimitReachedException();
+        }
+    }
+}

--- a/cache/SpfDnsCache.php
+++ b/cache/SpfDnsCache.php
@@ -48,8 +48,8 @@ class SpfDnsCache extends Model
         $parent = explode(".", $domainname, 2)[1] ?? $domainname;
         if (!$expiry) {
             $expiry = new \DateInterval(self::$expiry);
-            $validuntil = (new \DateTimeImmutable())->add($expiry);
         }
+        $validuntil = (new \DateTimeImmutable())->add($expiry);
         foreach ($txtrecords as $idx => $record) {
             $e = new self();
             $e->domainname = $domainname;

--- a/cache/SpfDnsCache.php
+++ b/cache/SpfDnsCache.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Laravel Model for SpfDnsCahce
+ *
+ * This implements the caching logic
+ *
+ * Copyright 2020 Rob Thomas <xrobau@gmail.com>
+ *
+ * @licence MIT
+ * @package App\Models
+ */
+class SpfDnsCache extends Model
+{
+    protected $table = "spf_dns_cache";
+    public $timestamps = false;
+
+    private static $expiry = 'P1D';
+
+    public static function lookup($domainname)
+    {
+        $parent = explode(".", $domainname, 2)[1] ?? $domainname;
+        $r = self::whereRaw('validuntil > NOW()')
+            ->where('domainname', '=', $domainname)
+            ->orWhere(function ($q) use ($parent) {
+                $q->where('parentdomain', '=', $parent)->where('iswildcard', '=', 1);
+            })
+            ->orderBy('txtrownum');
+        return $r->get();
+    }
+
+    public static function getTxtRecords($domainname)
+    {
+        $all = self::lookup($domainname);
+        $retarr = ["found" => count($all), "records" => []];
+        foreach ($all as $row) {
+            $retarr["records"][] = $row->txtvalue;
+        }
+        return $retarr;
+    }
+
+    public static function addEntry($domainname, array $txtrecords, $iswildcard = false, ?\DateInterval $expiry = null)
+    {
+        $parent = explode(".", $domainname, 2)[1] ?? $domainname;
+        if (!$expiry) {
+            $expiry = new \DateInterval(self::$expiry);
+            $validuntil = (new \DateTimeImmutable())->add($expiry);
+        }
+        foreach ($txtrecords as $idx => $record) {
+            $e = new self();
+            $e->domainname = $domainname;
+            $e->parentdomain = $parent;
+            $e->iswildcard = $iswildcard;
+            $e->validuntil = $validuntil;
+            $e->txtrownum = $idx;
+            $e->txtvalue = $record;
+            $e->save();
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "mika56/spfcheck",
+    "name": "xrobau/spfcheck",
     "description": "Checks an IP address against a domain's SPF record",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "4.8.* || 7.*",
+        "phpunit/phpunit": "^9",
         "symfony/yaml": "~2.1",
         "satooshi/php-coveralls": "~1.0",
         "symfony/phpunit-bridge": "^4.2 || 5.*"
@@ -16,10 +16,14 @@
         {
             "name": "Brian Tafoya",
             "email": "btafoya@briantafoya.com"
+        },
+        {
+            "name": "Rob Thomas",
+            "email": "xrobau@gmail.com"
         }
     ],
     "require": {
-        "symfony/http-foundation": "2.8.* || ^3.0 || ^4.0 || ^5.0",
+        "symfony/http-foundation": "*",
         "php": ">=5.4",
         "purplepixie/phpdns": "^2.0"
     },


### PR DESCRIPTION
This is some example Laravel code that can be used to cache lookups. This addresses #8 but would probably be better split out into a specific laravel package.
