### PR TITLE
Use fully qualified domain name in DNS queries

### DIFF
--- a/tests/DNSRecordGetterTest.php
+++ b/tests/DNSRecordGetterTest.php
@@ -14,13 +14,13 @@ class DNSRecordGetterTest extends TestCase
     public function testGetSPFRecordForDomain()
     {
         DnsMock::withMockedHosts([
-            'example.com'  => [
+            'example.com.'  => [
                 [
                     'type' => 'TXT',
                     'txt'  => 'v=spf1 a',
                 ],
             ],
-            'example2.com' => [
+            'example2.com.' => [
                 [
                     'type' => 'TXT',
                     'txt'  => 'v=spf1',
@@ -42,7 +42,7 @@ class DNSRecordGetterTest extends TestCase
     public function testResolveA()
     {
         DnsMock::withMockedHosts([
-            'example.com' => [
+            'example.com.' => [
                 [
                     'type' => 'A',
                     'ip'   => '1.2.3.4',
@@ -68,14 +68,14 @@ class DNSRecordGetterTest extends TestCase
     public function testResolveMx()
     {
         DnsMock::withMockedHosts([
-            'example.com'  => [
+            'example.com.'  => [
                 [
                     'type'   => 'MX',
                     'pri'    => 10,
                     'target' => 'mail.example.com',
                 ],
             ],
-            'example2.com' => [],
+            'example2.com.' => [],
         ]);
 
         $dnsRecordGetter = new DNSRecordGetter();
@@ -91,7 +91,7 @@ class DNSRecordGetterTest extends TestCase
     public function testResolvePtrIpv4()
     {
         DnsMock::withMockedHosts([
-            '1.0.0.127.in-addr.arpa' => [
+            '1.0.0.127.in-addr.arpa.' => [
                 [
                     'type'   => 'PTR',
                     'target' => 'example.com',
@@ -109,7 +109,7 @@ class DNSRecordGetterTest extends TestCase
     public function testResolvePtrIpv6()
     {
         DnsMock::withMockedHosts([
-            '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa' => [
+            '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa.' => [
                 [
                     'type'   => 'PTR',
                     'target' => 'example.com',


### PR DESCRIPTION
Hi!

SPF checks must be performed on fully qualified domain names (FQDN). This means, that when calling `dns_get_record()`, domain [must end with zero-length label](https://datatracker.ietf.org/doc/html/rfc7208#section-4.3) (dot).

Without dot at the end, resolver may search additional domain names, causing unnecessary delays or wrong results. In my case it tries to search `.local` domain, which tries to resolve non-existent A/AAAA records over mDNS, which causes long delays because of timeouts.

Here is a small pull-request to fix this.

BR,
Erki