### PR TITLE
PHP Support fixes

### DIFF
--- a/src/Exception/MacroSyntaxError.php
+++ b/src/Exception/MacroSyntaxError.php
@@ -8,7 +8,7 @@ class MacroSyntaxError extends \Exception
 {
     private bool $isFatal;
 
-    public function __construct(bool $isFatal, $message = "", $code = 0, \Throwable $previous = null)
+    public function __construct(bool $isFatal, $message = "", $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->isFatal = $isFatal;

--- a/src/MechanismEvaluator/IncludeEvaluator.php
+++ b/src/MechanismEvaluator/IncludeEvaluator.php
@@ -15,7 +15,7 @@ use Mika56\SPFCheck\Model\Result;
 class IncludeEvaluator implements EvaluatorInterface
 {
 
-    public static function matches(AbstractMechanism $mechanism, Query $query, Result $result, callable $doGetResult = null): bool
+    public static function matches(AbstractMechanism $mechanism, Query $query, Result $result, ?callable $doGetResult = null): bool
     {
         if(!$mechanism instanceof IncludeMechanism) {
             throw new \LogicException();


### PR DESCRIPTION
This update adds support for PHP 8.4. There were two parameters implicitly marked as null.